### PR TITLE
Robustly determine parent directories

### DIFF
--- a/src/configGenerator/configLocator.ts
+++ b/src/configGenerator/configLocator.ts
@@ -21,7 +21,7 @@ export async function findConfigFrom(path: string) {
   );
   assert(await isDir(path), '`path` must be a directory');
 
-  let oldPath = null;
+  let prevPath = null;
   let currentPath = resolve(path);
   do {
     try {
@@ -36,9 +36,9 @@ export async function findConfigFrom(path: string) {
       }
     }
 
-    oldPath = currentPath;
-    currentPath = dirname(oldPath);
-  } while (currentPath != oldPath);
+    prevPath = currentPath;
+    currentPath = dirname(prevPath);
+  } while (currentPath != prevPath);
 
   throw new Error(`Unable to locate ${CONFIG_FILENAME} on the current path`);
 }

--- a/src/configGenerator/configLocator.ts
+++ b/src/configGenerator/configLocator.ts
@@ -21,6 +21,7 @@ export async function findConfigFrom(path: string) {
   );
   assert(await isDir(path), '`path` must be a directory');
 
+  let oldPath = null;
   let currentPath = resolve(path);
   do {
     try {
@@ -35,8 +36,9 @@ export async function findConfigFrom(path: string) {
       }
     }
 
-    currentPath = dirname(currentPath);
-  } while (currentPath !== '.' && currentPath !== '/');
+    oldPath = currentPath;
+    currentPath = dirname(oldPath);
+  } while (currentPath != oldPath);
 
   throw new Error(`Unable to locate ${CONFIG_FILENAME} on the current path`);
 }


### PR DESCRIPTION
It's not safe to assume path separator or root character when walking up through parent directories. This can lead to an infinite loop in some cases and on some platforms. It's better to stop walking when the path is no longer getting shorter.

In this case, I simply break out of the loop when the old path and current path are the same. Alternatively, I could count characters and make sure it decrements on each iteration.