### PR TITLE
Spawn a shell for more reliable execution of yarn on some platforms.

### DIFF
--- a/.github/workflows/lint-typecheck-test-build-windows.yml
+++ b/.github/workflows/lint-typecheck-test-build-windows.yml
@@ -1,0 +1,40 @@
+name: Lint, Type Check, Test, Build on Windows
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  check:
+    name: Using Node ${{ matrix.node }} on Windows
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node: ['16.x', '18.x']
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Install wes-cli
+        run: |
+          npm i -g wes-cli@3.0.1
+          wes install
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Check Types
+        run: yarn check:types
+
+      - name: Test
+        run: yarn test:ci
+
+      - name: Build
+        run: yarn build

--- a/.wes-defaults/local/.github/workflows/lint-typecheck-test-build-windows.yml
+++ b/.wes-defaults/local/.github/workflows/lint-typecheck-test-build-windows.yml
@@ -1,0 +1,40 @@
+name: Lint, Type Check, Test, Build on Windows
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  check:
+    name: Using Node ${{ matrix.node }} on Windows
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node: ['16.x', '18.x']
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Install wes-cli
+        run: |
+          npm i -g wes-cli@3.0.1
+          wes install
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Check Types
+        run: yarn check:types
+
+      - name: Test
+        run: yarn test:ci
+
+      - name: Build
+        run: yarn build

--- a/src/configGenerator/configGenerator.ts
+++ b/src/configGenerator/configGenerator.ts
@@ -83,6 +83,7 @@ export async function generate({ workingDirectory = './' }) {
     await spawn('yarn', ['install'], {
       cwd: destinationPath,
       stdio: 'inherit',
+      shell: true,
     });
   }
 


### PR DESCRIPTION
I tried building lgtv-ip-control on Windows as I'm using my C2 as a gaming monitor. It was unable to launch yarn as Windows as it's invoked via yarn.cmd and Windows requires a shell to run .cmd scripts. The Node documentation recommends having the spawn command launch an OS-specific shell for you by simply passing the "shell: true" option.